### PR TITLE
Server Side pagination and filtering

### DIFF
--- a/backgrid-paginator.js
+++ b/backgrid-paginator.js
@@ -186,8 +186,14 @@
     changePage: function (e) {
       e.preventDefault();
       var $el = this.$el;
+      var theFilter = $(".backgrid-filter");
+      var data = {}
+      if ($(theFilter).length > 0){
+          var filterBox = $(theFilter).find("input[type='text']");
+          data[$(filterBox).attr("name")] = $(filterBox).val();
+      }
       if (!$el.hasClass("active") && !$el.hasClass("disabled")) {
-        this.collection.getPage(this.pageIndex);
+          this.collection.getPage(this.pageIndex, {data: data});
       }
       return this;
     }


### PR DESCRIPTION
When using server-side pagination and filtering together, pagination breaks when returning more than one page of search results.  
- Attempting to go to the next page of search results in the search query being dropped from the GET request.
