### PR TITLE
Update backgrid-paginator.js, Fixed goBackFirstOnSort

### DIFF
--- a/backgrid-paginator.js
+++ b/backgrid-paginator.js
@@ -261,7 +261,7 @@
       this.listenTo(collection, "add", this.render);
       this.listenTo(collection, "remove", this.render);
       this.listenTo(collection, "reset", this.render);
-      var goBackFirstOnSort = options.goBackFirstOnSort ? options.goBackFirstOnSort : this.goBackFirstOnSort;
+      var goBackFirstOnSort = options.goBackFirstOnSort !== undefined ? options.goBackFirstOnSort : this.goBackFirstOnSort;
       if (goBackFirstOnSort && collection.fullCollection) {
         this.listenTo(collection.fullCollection, "sort", function () {
           collection.getFirstPage();


### PR DESCRIPTION
Fixed goBackFirstOnSort, it was not possible to set this property to false
