### PR TITLE
Match version of backgrid-paginator on npm

### DIFF
--- a/backgrid-paginator.js
+++ b/backgrid-paginator.js
@@ -9,14 +9,14 @@
 
   // CommonJS
   if (typeof exports == "object") {
-    module.exports = factory(require("underscore"),
+    module.exports = factory(require("lodash"),
                              require("backbone"),
                              require("backgrid"),
                              require("backbone.paginator"));
   }
   // AMD. Register as an anonymous module.
   else if (typeof define === 'function' && define.amd) {
-    define(['underscore', 'backbone', 'backgrid', 'backbone.paginator'], factory);
+    define(['lodash', 'backbone', 'backgrid', 'backbone.paginator'], factory);
   }
   // Browser
   else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backgrid-paginator",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Backgrid.js extension for pagination.",
   "main": "backgrid-paginator.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,14 +21,18 @@
     "url": "https://github.com/wyuenho/backgrid-paginator/issues"
   },
   "devDependencies": {
-    "grunt-contrib-clean": "~0.4.1",
-    "grunt-jsduck": "~0.1.4",
-    "grunt-contrib-uglify": "~0.2.2",
-    "grunt-cli": "~0.1.9",
+    "backbone": "^1.1.2",
+    "backbone.paginator": "^2.0.2",
+    "backgrid": "^0.3.5",
     "grunt": "~0.4.1",
+    "grunt-cli": "~0.1.9",
+    "grunt-contrib-clean": "~0.4.1",
+    "grunt-contrib-jasmine": "~0.5.1",
+    "grunt-contrib-uglify": "~0.2.2",
+    "grunt-jsduck": "~0.1.4",
     "grunt-recess": "~0.3.3",
     "grunt-template-jasmine-istanbul": "~0.2.4",
-    "grunt-contrib-jasmine": "~0.5.1"
+    "underscore": "^1.8.2"
   },
   "private": true
 }

--- a/package.json
+++ b/package.json
@@ -20,10 +20,13 @@
   "bugs": {
     "url": "https://github.com/wyuenho/backgrid-paginator/issues"
   },
-  "devDependencies": {
+  "dependencies": {
     "backbone": "^1.1.2",
     "backbone.paginator": "^2.0.2",
     "backgrid": "^0.3.5",
+    "underscore": "^1.8.2"
+  },
+  "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.9",
     "grunt-contrib-clean": "~0.4.1",
@@ -31,8 +34,6 @@
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-jsduck": "~0.1.4",
     "grunt-recess": "~0.3.3",
-    "grunt-template-jasmine-istanbul": "~0.2.4",
-    "underscore": "^1.8.2"
-  },
-  "private": true
+    "grunt-template-jasmine-istanbul": "~0.2.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backgrid-paginator",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Backgrid.js extension for pagination.",
   "main": "backgrid-paginator.js",
   "scripts": {
@@ -24,7 +24,7 @@
     "backbone": "^1.1.2",
     "backbone.paginator": "^2.0.2",
     "backgrid": "^0.3.5",
-    "underscore": "^1.8.2"
+    "lodash": "^3.3.1"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
This PR updates the version to 0.3.7 that is the one currently published on npm.

I needed this on npm for one of my personal projects and I made the terrible decision of publishing my fork to npm with the same name as the original repo, I apologize for the confusion.

I'll cut a new release after this so we have the latest version deployed from the official repo (not my fork), and we match the git tags as well.